### PR TITLE
Add real-time note taking TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,10 +18,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "assert_cmd"
@@ -63,6 +122,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,10 +143,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compact_str"
@@ -105,6 +240,12 @@ checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crossterm"
@@ -305,6 +446,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +505,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,6 +524,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -441,6 +622,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "parking_lot"
@@ -551,6 +738,8 @@ name = "real_time_note_taker"
 version = "0.0.1"
 dependencies = [
  "assert_cmd",
+ "chrono",
+ "clap",
  "crossterm 0.29.0",
  "predicates",
  "ratatui",
@@ -670,6 +859,12 @@ checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
@@ -866,6 +1061,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,6 +1091,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,6 +1169,65 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ crossterm = "0.29.0"
 serde = { version = "1", features = ["derive"] }
 toml = "0.9.2"
 thiserror = "2.0.12"
+chrono = { version = "0.4", features = ["serde", "clock"] }
+clap = { version = "4", features = ["derive"] }
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # real_time_note_taker
-Take notes in real time
+
+A terminal user interface application for taking timestamped notes in real time. Press `Enter` to begin a note, type your text, and press `Enter` again to save. Press `Esc` to cancel a note. Quit the application with `q`.
+
+## Running
+
+```
+cargo run --release
+```
+
+## Library Usage
+
+```
+use real_time_note_taker::{run, App};
+
+fn main() -> std::io::Result<()> {
+    let app = App::new();
+    run(app)
+}
+```

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,0 +1,183 @@
+#![warn(clippy::pedantic)]
+use chrono::{DateTime, Local};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use std::io;
+use thiserror::Error;
+
+/// Represents a single note with timestamp.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Note {
+    /// The time the note was started.
+    pub timestamp: DateTime<Local>,
+    /// The contents of the note.
+    pub text: String,
+}
+
+/// Input mode for the application.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputMode {
+    /// Normal mode where key events control the application.
+    Normal,
+    /// Editing mode for entering note text.
+    Editing,
+}
+
+impl Default for InputMode {
+    fn default() -> Self {
+        Self::Normal
+    }
+}
+
+/// Errors that can occur within the application.
+#[derive(Error, Debug)]
+pub enum AppError {
+    /// I/O error.
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+/// Main application state.
+#[derive(Debug, Default)]
+pub struct App {
+    /// Collected notes.
+    pub notes: Vec<Note>,
+    /// Current input buffer when editing.
+    input: String,
+    /// Current mode.
+    mode: InputMode,
+    /// Timestamp captured when note editing started.
+    note_time: Option<DateTime<Local>>,
+}
+
+impl App {
+    /// Creates a new [`App`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns current input mode.
+    #[must_use]
+    pub const fn mode(&self) -> InputMode {
+        self.mode
+    }
+
+    /// Returns current input buffer.
+    #[must_use]
+    pub fn input(&self) -> &str {
+        &self.input
+    }
+
+    /// Starts a new note capturing the current timestamp.
+    pub fn start_note(&mut self) {
+        self.note_time = Some(Local::now());
+        self.input.clear();
+        self.mode = InputMode::Editing;
+    }
+
+    /// Finalizes the note if editing, pushing it into the note list.
+    pub fn finalize_note(&mut self) {
+        if let Some(time) = self.note_time.take() {
+            self.notes.push(Note {
+                timestamp: time,
+                text: self.input.drain(..).collect(),
+            });
+            self.mode = InputMode::Normal;
+        }
+    }
+
+    /// Cancels the current note editing.
+    pub fn cancel_note(&mut self) {
+        self.input.clear();
+        self.note_time = None;
+        self.mode = InputMode::Normal;
+    }
+
+    /// Handles a terminal event.
+    ///
+    /// # Errors
+    /// Propagates any I/O errors from the terminal event system.
+    pub fn handle_event(&mut self, event: Event) -> Result<(), AppError> {
+        match (self.mode, event) {
+            (
+                InputMode::Normal,
+                Event::Key(KeyEvent {
+                    code: KeyCode::Enter,
+                    ..
+                }),
+            ) => {
+                self.start_note();
+            }
+            (
+                InputMode::Editing,
+                Event::Key(KeyEvent {
+                    code: KeyCode::Enter,
+                    ..
+                }),
+            ) => {
+                self.finalize_note();
+            }
+            (
+                InputMode::Editing,
+                Event::Key(KeyEvent {
+                    code: KeyCode::Esc, ..
+                }),
+            ) => {
+                self.cancel_note();
+            }
+            (
+                InputMode::Editing,
+                Event::Key(KeyEvent {
+                    code: KeyCode::Char(c),
+                    modifiers: KeyModifiers::NONE | KeyModifiers::SHIFT,
+                    ..
+                }),
+            ) => {
+                self.input.push(c);
+            }
+            (
+                InputMode::Editing,
+                Event::Key(KeyEvent {
+                    code: KeyCode::Backspace,
+                    ..
+                }),
+            ) => {
+                self.input.pop();
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn start_and_finalize_note() {
+        let mut app = App::new();
+        assert!(app.notes.is_empty());
+        app.start_note();
+        assert!(matches!(app.mode(), InputMode::Editing));
+        assert!(app.note_time.is_some());
+        app.input.push_str("test");
+        app.finalize_note();
+        assert!(app.note_time.is_none());
+        assert!(matches!(app.mode(), InputMode::Normal));
+        assert_eq!(app.notes.len(), 1);
+        assert_eq!(app.notes[0].text, "test");
+    }
+
+    #[test]
+    fn cancel_note() {
+        let mut app = App::new();
+        app.start_note();
+        app.input.push_str("discard");
+        app.cancel_note();
+        assert!(app.notes.is_empty());
+        assert!(app.input.is_empty());
+        assert!(app.note_time.is_none());
+        assert!(matches!(app.mode(), InputMode::Normal));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,50 @@
-//! # Project-NAme
+#![warn(clippy::pedantic)]
+//! # `real_time_note_taker`
 //!
-//! A library for ...
+//! A reusable library providing a terminal user interface to take timestamped
+//! notes in real time.
 //!
 //! ## Example
 //!
-//! ```rust
-//! 
+//! ```no_run
+//! use real_time_note_taker::{run, App};
+//!
+//! fn main() -> std::io::Result<()> {
+//!     let app = App::new();
+//!     run(app)
+//! }
 //! ```
 
-#![warn(clippy::pedantic)]
+mod app;
+mod ui;
 
-mod mod1;
-mod mod2;
+pub use app::{App, AppError, InputMode, Note};
+use std::io;
 
+/// Runs the real-time note taking application.
+///
+/// # Arguments
+/// * `app` - Initial application state.
+///
+/// # Errors
+/// Propagates any terminal initialization or rendering errors.
+///
+/// # See also
+/// [`App`] for manipulating the application state directly.
+pub fn run(app: App) -> io::Result<()> {
+    let mut terminal = ui::init_terminal()?;
+    let res = ui::run_ui(&mut terminal, app);
+    ui::restore_terminal(&mut terminal)?;
+    res
+}
 
-/// description
-pub use mod1;
-/// description
-pub use mod2;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
+    #[test]
+    fn create_app() {
+        let app = App::new();
+        assert!(app.notes.is_empty());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,25 @@
 #![warn(clippy::pedantic)]
+use clap::Parser;
+use real_time_note_taker::{run, App};
 
-fn main() -> Result<(), Box<dyn Error>> {
-    Ok(())
+#[derive(Parser)]
+#[command(author, version, about)]
+struct Cli {}
+
+fn main() -> std::io::Result<()> {
+    let _ = Cli::parse();
+    let app = App::new();
+    run(app)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use assert_cmd::Command;
 
     #[test]
-    fn tests() {
-        assert_eq!(0, 0);
+    fn runs_help() {
+        let mut cmd = Command::cargo_bin("rtnt").unwrap();
+        let assert = cmd.arg("--help").assert();
+        assert.success();
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,96 @@
+#![warn(clippy::pedantic)]
+use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, Event as CEvent, KeyCode};
+use crossterm::execute;
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
+use ratatui::Terminal;
+use std::io::{self, Stdout};
+use std::time::{Duration, Instant};
+
+use crate::{App, InputMode};
+
+/// Initializes the terminal for TUI rendering.
+pub fn init_terminal() -> io::Result<Terminal<CrosstermBackend<Stdout>>> {
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
+    Terminal::new(backend)
+}
+
+/// Restores the terminal to its previous state.
+pub fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> io::Result<()> {
+    disable_raw_mode()?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
+    terminal.show_cursor()?;
+    Ok(())
+}
+
+/// Runs the UI event loop with the provided application state.
+pub fn run_ui(terminal: &mut Terminal<CrosstermBackend<Stdout>>, mut app: App) -> io::Result<()> {
+    let tick_rate = Duration::from_millis(200);
+    let mut last_tick = Instant::now();
+    loop {
+        terminal.draw(|f| draw(f, &app))?;
+        let timeout = tick_rate.saturating_sub(last_tick.elapsed());
+        if crossterm::event::poll(timeout)? {
+            match event::read()? {
+                CEvent::Key(key) if key.code == KeyCode::Char('q') => break,
+                ev => {
+                    app.handle_event(ev).ok();
+                }
+            }
+        }
+        if last_tick.elapsed() >= tick_rate {
+            last_tick = Instant::now();
+        }
+    }
+    Ok(())
+}
+
+fn draw(f: &mut ratatui::Frame<'_>, app: &App) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(1)
+        .constraints([Constraint::Min(1), Constraint::Length(3)].as_ref())
+        .split(f.area());
+
+    let notes: Vec<ListItem> = app
+        .notes
+        .iter()
+        .map(|n| {
+            ListItem::new(Line::from(vec![
+                Span::styled(
+                    n.timestamp.format("%H:%M:%S").to_string(),
+                    Style::default().add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(" - "),
+                Span::raw(&n.text),
+            ]))
+        })
+        .collect();
+
+    let notes_list = List::new(notes).block(Block::default().borders(Borders::ALL).title("Notes"));
+    f.render_widget(notes_list, chunks[0]);
+
+    let input =
+        Paragraph::new(app.input()).block(Block::default().borders(Borders::ALL).title("Input"));
+    if matches!(app.mode(), InputMode::Editing) {
+        let offset = u16::try_from(app.input().len()).unwrap_or(u16::MAX);
+        f.set_cursor_position((
+            chunks[1].x.saturating_add(offset.saturating_add(1)),
+            chunks[1].y + 1,
+        ));
+    }
+    f.render_widget(input, chunks[1]);
+}


### PR DESCRIPTION
## Summary
- implement `App` and event handling for taking notes
- build TUI UI layer with ratatui
- expose library API and runnable binary
- document usage in README
- add tests and run with clap for `--help`

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`

