### PR TITLE
Fix nextest failure

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,12 +14,7 @@ fn main() -> std::io::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use assert_cmd::Command;
-
-    #[test]
-    fn runs_help() {
-        let mut cmd = Command::cargo_bin("rtnt").unwrap();
-        let assert = cmd.arg("--help").assert();
-        assert.success();
-    }
+    // The CLI behavior is tested in `tests/cli.rs` as an integration test so that
+    // `assert_cmd` can locate the compiled binary. This module is intentionally
+    // left empty.
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,7 @@
+use assert_cmd::Command;
+
+#[test]
+fn runs_help() {
+    let mut cmd = Command::cargo_bin("rtnt").unwrap();
+    cmd.arg("--help").assert().success();
+}


### PR DESCRIPTION
## Summary
- move CLI test into `tests/cli.rs`
- keep unit test module in `src/main.rs` empty with pointer to integration test

## Testing
- `cargo test`
- `cargo nextest run`

