### PR TITLE
Add editing keybind

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # real_time_note_taker
 
-A terminal user interface application for taking timestamped notes in real time. Press `Enter` to begin a note, type your text, and press `Enter` again to save. Press `s` to start a section and enter a title. Press `Esc` to cancel an entry. Quit the application with `q`.
+A terminal user interface application for taking timestamped notes in real time. Press `Enter` to begin a note, type your text, and press `Enter` again to save. Press `s` to start a section and enter a title. Use the arrow keys to select a previous entry and press `e` to edit it. Press `Esc` to cancel an entry. Quit the application with `q`.
 
 ## Running
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -38,6 +38,10 @@ pub enum InputMode {
     EditingNote,
     /// Editing mode for entering a section title.
     EditingSection,
+    /// Editing an existing note.
+    EditingExistingNote,
+    /// Editing an existing section title.
+    EditingExistingSection,
 }
 
 impl Default for InputMode {
@@ -67,6 +71,10 @@ pub struct App {
     mode: InputMode,
     /// Timestamp captured when note editing started.
     note_time: Option<DateTime<Local>>,
+    /// Selected entry index when navigating.
+    selected: Option<usize>,
+    /// Index of the entry currently being edited if editing an existing entry.
+    edit_index: Option<usize>,
 }
 
 impl App {
@@ -94,10 +102,54 @@ impl App {
         self.note_time
     }
 
+    /// Returns the currently selected entry index if any.
+    #[must_use]
+    pub const fn selected(&self) -> Option<usize> {
+        self.selected
+    }
+
+    /// Move selection to the previous entry if any.
+    pub fn select_previous(&mut self) {
+        match self.selected {
+            Some(0) | None => {}
+            Some(i) => self.selected = Some(i - 1),
+        }
+    }
+
+    /// Move selection to the next entry if any.
+    pub fn select_next(&mut self) {
+        match self.selected {
+            Some(i) if i + 1 < self.entries.len() => self.selected = Some(i + 1),
+            None if !self.entries.is_empty() => self.selected = Some(0),
+            _ => {}
+        }
+    }
+
+    /// Begin editing the selected entry if any.
+    pub fn edit_selected(&mut self) {
+        if let Some(idx) = self.selected {
+            match &self.entries[idx] {
+                Entry::Note(n) => {
+                    self.input = n.text.clone();
+                    self.note_time = Some(n.timestamp);
+                    self.edit_index = Some(idx);
+                    self.mode = InputMode::EditingExistingNote;
+                }
+                Entry::Section(s) => {
+                    self.input = s.title.clone();
+                    self.note_time = None;
+                    self.edit_index = Some(idx);
+                    self.mode = InputMode::EditingExistingSection;
+                }
+            }
+        }
+    }
+
     /// Starts a new note capturing the current timestamp.
     pub fn start_note(&mut self) {
         self.note_time = Some(Local::now());
         self.input.clear();
+        self.edit_index = None;
         self.mode = InputMode::EditingNote;
     }
 
@@ -105,18 +157,33 @@ impl App {
     pub fn start_section(&mut self) {
         self.note_time = None;
         self.input.clear();
+        self.edit_index = None;
         self.mode = InputMode::EditingSection;
     }
 
     /// Finalizes the note if editing, pushing it into the note list.
     pub fn finalize_note(&mut self) {
-        if let Some(time) = self.note_time.take() {
+        if let Some(idx) = self.edit_index.take() {
+            if let Entry::Note(ref mut n) = self.entries[idx] {
+                n.text = self.input.drain(..).collect();
+                if let Some(orig) = self
+                    .notes
+                    .iter_mut()
+                    .find(|orig| orig.timestamp == n.timestamp)
+                {
+                    orig.text = n.text.clone();
+                }
+            }
+            self.mode = InputMode::Normal;
+            self.note_time = None;
+        } else if let Some(time) = self.note_time.take() {
             let note = Note {
                 timestamp: time,
                 text: self.input.drain(..).collect(),
             };
             self.notes.push(note.clone());
             self.entries.push(Entry::Note(note));
+            self.selected = Some(self.entries.len() - 1);
             self.mode = InputMode::Normal;
         }
     }
@@ -124,9 +191,15 @@ impl App {
     /// Finalizes a section entry.
     pub fn finalize_section(&mut self) {
         let title = self.input.drain(..).collect::<String>();
-        if !title.is_empty() {
+        if let Some(idx) = self.edit_index.take() {
+            if let Entry::Section(ref mut s) = self.entries[idx] {
+                s.title = title;
+            }
+            self.note_time = None;
+        } else if !title.is_empty() {
             let section = Section { title };
             self.entries.push(Entry::Section(section));
+            self.selected = Some(self.entries.len() - 1);
         }
         self.mode = InputMode::Normal;
     }
@@ -135,6 +208,7 @@ impl App {
     pub fn cancel_entry(&mut self) {
         self.input.clear();
         self.note_time = None;
+        self.edit_index = None;
         self.mode = InputMode::Normal;
     }
 
@@ -144,6 +218,32 @@ impl App {
     /// Propagates any I/O errors from the terminal event system.
     pub fn handle_event(&mut self, event: Event) -> Result<(), AppError> {
         match (self.mode, event) {
+            (
+                InputMode::Normal,
+                Event::Key(KeyEvent {
+                    code: KeyCode::Up, ..
+                }),
+            ) => {
+                self.select_previous();
+            }
+            (
+                InputMode::Normal,
+                Event::Key(KeyEvent {
+                    code: KeyCode::Down,
+                    ..
+                }),
+            ) => {
+                self.select_next();
+            }
+            (
+                InputMode::Normal,
+                Event::Key(KeyEvent {
+                    code: KeyCode::Char('e'),
+                    ..
+                }),
+            ) => {
+                self.edit_selected();
+            }
             (
                 InputMode::Normal,
                 Event::Key(KeyEvent {
@@ -163,7 +263,7 @@ impl App {
                 self.start_section();
             }
             (
-                InputMode::EditingNote,
+                InputMode::EditingNote | InputMode::EditingExistingNote,
                 Event::Key(KeyEvent {
                     code: KeyCode::Enter,
                     ..
@@ -172,7 +272,7 @@ impl App {
                 self.finalize_note();
             }
             (
-                InputMode::EditingSection,
+                InputMode::EditingSection | InputMode::EditingExistingSection,
                 Event::Key(KeyEvent {
                     code: KeyCode::Enter,
                     ..
@@ -181,7 +281,10 @@ impl App {
                 self.finalize_section();
             }
             (
-                InputMode::EditingNote | InputMode::EditingSection,
+                InputMode::EditingNote
+                | InputMode::EditingSection
+                | InputMode::EditingExistingNote
+                | InputMode::EditingExistingSection,
                 Event::Key(KeyEvent {
                     code: KeyCode::Esc, ..
                 }),
@@ -189,7 +292,10 @@ impl App {
                 self.cancel_entry();
             }
             (
-                InputMode::EditingNote | InputMode::EditingSection,
+                InputMode::EditingNote
+                | InputMode::EditingSection
+                | InputMode::EditingExistingNote
+                | InputMode::EditingExistingSection,
                 Event::Key(KeyEvent {
                     code: KeyCode::Char(c),
                     modifiers: KeyModifiers::NONE | KeyModifiers::SHIFT,
@@ -199,7 +305,10 @@ impl App {
                 self.input.push(c);
             }
             (
-                InputMode::EditingNote | InputMode::EditingSection,
+                InputMode::EditingNote
+                | InputMode::EditingSection
+                | InputMode::EditingExistingNote
+                | InputMode::EditingExistingSection,
                 Event::Key(KeyEvent {
                     code: KeyCode::Backspace,
                     ..

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -86,27 +86,32 @@ fn draw(f: &mut ratatui::Frame<'_>, app: &App) {
         })
         .collect();
 
-    let notes_list = List::new(notes).block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_type(BorderType::Thick)
-            .title("Notes"),
-    );
+    let notes_list = List::new(notes)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Thick)
+                .title("Notes"),
+        )
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
 
     let visible_height = usize::from(chunks[0].height.saturating_sub(2));
     let offset = app.entries.len().saturating_sub(visible_height);
     let mut state = ListState::default().with_offset(offset);
+    if let Some(sel) = app.selected() {
+        state.select(Some(sel));
+    }
     f.render_stateful_widget(notes_list, chunks[0], &mut state);
 
     let input_title = match app.mode() {
-        InputMode::EditingNote => {
+        InputMode::EditingNote | InputMode::EditingExistingNote => {
             if let Some(time) = app.note_time() {
                 format!("Note - {}", time.format("%H:%M:%S%.3f"))
             } else {
                 "Note".to_string()
             }
         }
-        InputMode::EditingSection => "Section".to_string(),
+        InputMode::EditingSection | InputMode::EditingExistingSection => "Section".to_string(),
         InputMode::Normal => "Input".to_string(),
     };
 
@@ -116,7 +121,10 @@ fn draw(f: &mut ratatui::Frame<'_>, app: &App) {
         .title(input_title);
     if matches!(
         app.mode(),
-        InputMode::EditingNote | InputMode::EditingSection
+        InputMode::EditingNote
+            | InputMode::EditingSection
+            | InputMode::EditingExistingNote
+            | InputMode::EditingExistingSection
     ) {
         input_block = input_block.style(Style::default().fg(Color::Yellow));
     }
@@ -124,7 +132,10 @@ fn draw(f: &mut ratatui::Frame<'_>, app: &App) {
     let input = Paragraph::new(app.input()).block(input_block);
     if matches!(
         app.mode(),
-        InputMode::EditingNote | InputMode::EditingSection
+        InputMode::EditingNote
+            | InputMode::EditingSection
+            | InputMode::EditingExistingNote
+            | InputMode::EditingExistingSection
     ) {
         let offset = u16::try_from(app.input().len()).unwrap_or(u16::MAX);
         f.set_cursor_position((


### PR DESCRIPTION
## Summary
- add arrow key navigation and `e` to edit entries
- support editing existing notes and sections
- highlight selection in the UI
- document new keybindings in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68884632dcf48327bbce3f0f004acfe2