### PR TITLE
Add customizable key bindings and help display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # real_time_note_taker
 
-A terminal user interface application for taking timestamped notes in real time. Press `Enter` to begin a note, type your text, and press `Enter` again to save. Press `s` to start a section and enter a title. Use the arrow keys to select a previous entry and press `e` to edit it. Press `Esc` to cancel an entry. Press `w` to save all notes to a file and `l` to load from a file. Files are saved in CSV format under a platform‑appropriate directory shown in the prompt and created automatically if it does not exist. Quit the application with `q`. Use `--file <PATH>` to load and save notes automatically.
+A terminal user interface application for taking timestamped notes in real time. The bottom of the interface lists the active key bindings. By default press `Enter` to begin a note, type your text, and press `Enter` again to save. Press `s` to start a section and enter a title. Use the arrow keys to navigate through existing entries and press `e` to edit one. Press `Esc` to cancel an entry. Press `w` to save all notes to a file and `l` to load from a file. Files are saved in CSV format under a platform‑appropriate directory shown in the prompt and created automatically if it does not exist. Quit the application with `q`. Use `--file <PATH>` to load and save notes automatically.
+
+Key bindings can be customized by constructing the [`App`] with [`KeyBindings`](src/app.rs) using `App::with_keybindings` or by calling `App::set_keybindings`.
 
 When loading, an overlay window lists the files in this directory for selection.
 


### PR DESCRIPTION
## Summary
- add `KeyBindings` struct
- allow customizing App key bindings
- show a help bar with active keys
- document key binding customization

## Testing
- `cargo test`
- `cargo build --quiet`

------
https://chatgpt.com/codex/tasks/task_e_688955b44ae48327a0a3e26c8df06576