### PR TITLE
Enable left/right cursor movement while editing

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -189,7 +189,7 @@ fn draw(f: &mut ratatui::Frame<'_>, app: &App) {
             | InputMode::Saving
             | InputMode::Loading
     ) {
-        let offset = u16::try_from(app.input().len()).unwrap_or(u16::MAX);
+        let offset = u16::try_from(app.cursor()).unwrap_or(u16::MAX);
         f.set_cursor_position((
             chunks[1].x.saturating_add(offset.saturating_add(1)),
             chunks[1].y + 1,


### PR DESCRIPTION
## Summary
- track cursor position in `App`
- support Left and Right keys for navigation during editing
- draw cursor at the current position
- add regression test for arrow navigation

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68895d02f2908327b268f0558dee2375