### PR TITLE
Enhanced README and doc comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,24 @@
 # Real Time Note Taker
 
-Real Time Note Taker (RTNT) is a terminal user interface application for recording timestamped notes. Notes are grouped into optional sections and stored in CSV format for easy processing by other tools. All active key bindings are shown at the bottom of the interface.
+**RTNT** is a terminal user interface for taking timestamped notes. Notes can be organized into titled sections and exported to CSV for further processing. All active key bindings are always visible at the bottom of the UI.
+
+![Demo of RTNT](readme_resources/demo.gif)
 
 ## Features
 
 - Millisecond accurate timestamps
 - Section markers to organize discussions
 - Edit existing entries
-- Save and load notes to CSV files
+- Save and load notes from CSV
 - Fully keyboard driven with customizable bindings
+
+## Installation
+
+Add the binary with Cargo once the crate is published:
+
+```bash
+cargo install real_time_note_taker
+```
 
 ## Running
 
@@ -16,17 +26,13 @@ Real Time Note Taker (RTNT) is a terminal user interface application for recordi
 cargo run --release
 ```
 
-### Custom key bindings
-
-Press the key shown as `Keys` in the help line to open the key binding menu. Use
-the arrow keys to select an action and press <kbd>Enter</kbd> to assign a new
-key. If the chosen key is already bound you will be asked to confirm replacing
-that binding. Bindings are stored in `keybindings.json` inside the application
-configuration directory (typically `~/.config/rtnt`).
-
 ### Automatic file mode
 
-Passing `--file <PATH>` to the binary will load notes from the given file and automatically save them back on exit.
+Passing `--file <PATH>` will load notes from the given file and save them back on exit.
+
+### Custom key bindings
+
+Press the key shown as `Keys` in the help line to open the binding menu. Use the arrow keys to select an action and press <kbd>Enter</kbd> to assign a new key. Bindings are stored in `keybindings.json` inside the configuration directory (typically `~/.config/rtnt`).
 
 ## Library Usage
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -435,6 +435,20 @@ impl Default for App {
 
 impl App {
     /// Returns the directory where files are saved by default.
+    ///
+    /// # Returns
+    /// Path to the directory used for storing note CSV files.
+    ///
+    /// # Examples
+    /// ```
+    /// use real_time_note_taker::App;
+    ///
+    /// let path = App::default_save_dir();
+    /// println!("{:?}", path);
+    /// ```
+    ///
+    /// # See also
+    /// [`App::save_to_file`], [`App::load_from_file`]
     #[must_use]
     pub fn default_save_dir() -> PathBuf {
         if let Some(dirs) = ProjectDirs::from("com", "DFS", "rtnt") {
@@ -443,7 +457,18 @@ impl App {
             std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
         }
     }
-    /// Creates a new [`App`].
+    /// Creates a new [`App`] with default settings.
+    ///
+    /// # Returns
+    /// A fresh [`App`] ready to be passed to [`crate::run`].
+    ///
+    /// # Examples
+    /// ```
+    /// use real_time_note_taker::App;
+    ///
+    /// let app = App::new();
+    /// assert!(app.notes.is_empty());
+    /// ```
     #[must_use]
     pub fn new() -> Self {
         Self::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,16 +24,31 @@ pub use app::{Action, App, AppError, Entry, InputMode, Note, Section};
 use std::io;
 pub use theme::{Theme, ThemeName};
 
-/// Runs the real-time note taking application.
+/// Runs the real-time note taking application until the user exits.
 ///
 /// # Arguments
-/// * `app` - Initial application state.
+/// * `app` - Initial [`App`] state to run.
+///
+/// # Returns
+/// The final [`App`] state when the UI terminates.
+///
+/// # Examples
+/// ```no_run
+/// use real_time_note_taker::{run, App};
+///
+/// fn main() -> std::io::Result<()> {
+///     let app = App::new();
+///     let finished = run(app)?;
+///     println!("{} notes", finished.notes.len());
+///     Ok(())
+/// }
+/// ```
 ///
 /// # Errors
 /// Propagates any terminal initialization or rendering errors.
 ///
 /// # See also
-/// [`App`] for manipulating the application state directly.
+/// [`App::new`], [`App::save_to_file`]
 pub fn run(app: App) -> io::Result<App> {
     let mut terminal = ui::init_terminal()?;
     let res = ui::run_ui(&mut terminal, app);


### PR DESCRIPTION
## Summary
- improve README with installation instructions and screenshot
- document `run`, `App::new` and `App::default_save_dir`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68898dfada288327807193c8777c5e85