### PR TITLE
Prevent duplicate key handling on Windows

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::pedantic)]
 use chrono::{DateTime, Local};
-use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -954,6 +954,9 @@ impl App {
     /// Propagates any I/O errors from the terminal event system.
     pub fn handle_event(&mut self, event: &Event) -> Result<(), AppError> {
         if let Event::Key(key) = *event {
+            if key.kind != KeyEventKind::Press {
+                return Ok(());
+            }
             match self.mode {
                 InputMode::Normal => self.handle_normal_key(key),
                 InputMode::Loading => self.handle_loading_key(key),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -82,12 +82,16 @@ pub fn run_ui(terminal: &mut Terminal<CrosstermBackend<Stdout>>, mut app: App) -
         terminal.draw(|f| draw(f, &app))?;
         let timeout = tick_rate.saturating_sub(last_tick.elapsed());
         if crossterm::event::poll(timeout)? {
-            match event::read()? {
-                CEvent::Key(key) if key.code == app.keys.quit => break,
-                ev => {
-                    app.handle_event(&ev).ok();
+            let ev = event::read()?;
+            if let CEvent::Key(key) = &ev {
+                if key.kind != event::KeyEventKind::Press {
+                    continue;
+                }
+                if key.code == app.keys.quit {
+                    break;
                 }
             }
+            app.handle_event(&ev).ok();
         }
         if last_tick.elapsed() >= tick_rate {
             last_tick = Instant::now();


### PR DESCRIPTION
## Summary
- ignore key events that are not presses so that a key press doesn't
  trigger twice on Windows
- apply the same filter in the main UI loop
