### PR TITLE
Add colored theme names

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::too_many_lines)]
 use directories::ProjectDirs;
-use ratatui::style::Color;
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
@@ -73,6 +74,35 @@ impl ThemeName {
             Self::ToxicOrchid => "Toxic Orchid",
             Self::Coldfire => "Coldfire",
         }
+    }
+
+    #[must_use]
+    /// Returns the primary, secondary, and tertiary colors for this theme.
+    pub const fn colors(self) -> (Color, Color, Color) {
+        match self {
+            Self::Default => (Color::White, Color::Black, Color::Black),
+            Self::Matrix => (Color::LightGreen, Color::Green, Color::Black),
+            Self::CyanCrush => (Color::Cyan, Color::LightMagenta, Color::Black),
+            Self::Embercore => (Color::Red, Color::Yellow, Color::Black),
+            Self::ToxicOrchid => (Color::LightMagenta, Color::LightGreen, Color::Black),
+            Self::Coldfire => (Color::LightBlue, Color::LightRed, Color::Black),
+        }
+    }
+
+    #[must_use]
+    /// Formatted display name with alternating primary and secondary colors.
+    pub fn styled_display_name(self) -> Line<'static> {
+        let name = self.display_name();
+        let (primary, secondary, _) = self.colors();
+        let spans: Vec<Span> = name
+            .chars()
+            .enumerate()
+            .map(|(i, c)| {
+                let color = if i % 2 == 0 { primary } else { secondary };
+                Span::styled(c.to_string(), Style::from(color))
+            })
+            .collect();
+        Line::from(spans)
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -445,12 +445,7 @@ fn draw(f: &mut ratatui::Frame<'_>, app: &App) {
         f.render_widget(Clear, area);
         let items: Vec<ListItem> = ThemeName::ALL
             .iter()
-            .map(|t| {
-                ListItem::new(Span::styled(
-                    t.display_name(),
-                    Style::default().fg(theme.overlay_text),
-                ))
-            })
+            .map(|t| ListItem::new(t.styled_display_name()))
             .collect();
         let mut state = ListState::default();
         state.select(Some(app.theme_selected));


### PR DESCRIPTION
## Summary
- add `styled_display_name` helper
- show alternating primary/secondary colors in theme menu

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688abc4023348327928c864e6621cb70