### PR TITLE
Colorful theme picker

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -97,6 +97,8 @@ pub struct Theme {
     pub editing_fg: Color,
     pub editing_title: Color,
     pub overlay_text: Color,
+    primary: Color,
+    secondary: Color,
 }
 
 impl Theme {
@@ -122,7 +124,19 @@ impl Theme {
             editing_fg: secondary,
             editing_title: primary,
             overlay_text: primary,
+            primary,
+            secondary,
         }
+    }
+
+    #[must_use]
+    pub const fn primary_color(&self) -> Color {
+        self.primary
+    }
+
+    #[must_use]
+    pub const fn secondary_color(&self) -> Color {
+        self.secondary
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -448,12 +448,13 @@ fn draw(f: &mut ratatui::Frame<'_>, app: &App) {
             .enumerate()
             .map(|(idx, t)| {
                 let item_theme = t.theme();
-                let base_style = if idx == app.theme_selected {
-                    Style::default().fg(item_theme.secondary_color())
+                let base_style = Style::default().fg(item_theme.primary_color());
+                let style = if idx == app.theme_selected {
+                    base_style.bg(item_theme.secondary_color())
                 } else {
-                    Style::default().fg(item_theme.primary_color())
+                    base_style
                 };
-                ListItem::new(Span::styled(t.display_name(), base_style))
+                ListItem::new(Span::styled(t.display_name(), style))
             })
             .collect();
         let mut state = ListState::default();
@@ -467,11 +468,9 @@ fn draw(f: &mut ratatui::Frame<'_>, app: &App) {
             .border_type(BorderType::Plain)
             .border_style(Style::default().fg(theme.overlay_border))
             .style(Style::default().bg(theme.overlay_bg));
-        let list = List::new(items).block(block).highlight_style(
-            Style::default()
-                .bg(theme.overlay_highlight_bg)
-                .add_modifier(Modifier::BOLD),
-        );
+        let list = List::new(items)
+            .block(block)
+            .highlight_style(Style::default().add_modifier(Modifier::BOLD));
         f.render_stateful_widget(list, area, &mut state);
     } else if matches!(app.mode(), InputMode::KeyCapture) {
         if let Some(action) = app.capture_action {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -445,11 +445,15 @@ fn draw(f: &mut ratatui::Frame<'_>, app: &App) {
         f.render_widget(Clear, area);
         let items: Vec<ListItem> = ThemeName::ALL
             .iter()
-            .map(|t| {
-                ListItem::new(Span::styled(
-                    t.display_name(),
-                    Style::default().fg(theme.overlay_text),
-                ))
+            .enumerate()
+            .map(|(idx, t)| {
+                let item_theme = t.theme();
+                let base_style = if idx == app.theme_selected {
+                    Style::default().fg(item_theme.secondary_color())
+                } else {
+                    Style::default().fg(item_theme.primary_color())
+                };
+                ListItem::new(Span::styled(t.display_name(), base_style))
             })
             .collect();
         let mut state = ListState::default();
@@ -466,7 +470,6 @@ fn draw(f: &mut ratatui::Frame<'_>, app: &App) {
         let list = List::new(items).block(block).highlight_style(
             Style::default()
                 .bg(theme.overlay_highlight_bg)
-                .fg(theme.overlay_highlight_fg)
                 .add_modifier(Modifier::BOLD),
         );
         f.render_stateful_widget(list, area, &mut state);


### PR DESCRIPTION
## Summary
- expose primary and secondary colors in `Theme`
- colorize the theme selection menu using the individual theme colors

## Testing
- `cargo test --quiet`
- `cargo fmt -- --check`


------
https://chatgpt.com/codex/tasks/task_e_688abe0bd3c48327af2ec37779a9ddf4