### PR TITLE
Improve CLI options and docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5abde44486daf70c5be8b8f8f1b66c49f86236edf6fa2abadb4d961c4c6229a"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +425,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +521,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +579,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -799,9 +844,12 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
+ "clap_complete",
  "crossterm 0.29.0",
  "csv",
  "directories",
+ "env_logger",
+ "log",
  "predicates",
  "ratatui",
  "serde",
@@ -1036,6 +1084,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,6 +1276,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ csv = "1"
 thiserror = "2.0.12"
 chrono = { version = "0.4", features = ["serde", "clock"] }
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
+log = "0.4"
+env_logger = "0.10"
 directories = "5"
 serde_json = "1"
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ cargo install real_time_note_taker
 cargo run --release
 ```
 
+Additional CLI options are available:
+
+- `--save-dir <PATH>` to override the default save location
+- `--config <FILE>` to load key bindings from a custom file
+- `-v/--verbose` increase logging output
+- `completions <SHELL>` generate shell completion scripts
+
 ### Automatic file mode
 
 Passing `--file <PATH>` will load notes from the given file and save them back on exit.
@@ -41,6 +48,28 @@ Passing `--file <PATH>` will load notes from the given file and save them back o
 ### Custom key bindings
 
 Press the key shown as `Keys` in the help line to open the binding menu. Use the arrow keys to select an action and press <kbd>Enter</kbd> to assign a new key. Bindings are stored in `keybindings.json` inside the configuration directory (typically `~/.config/rtnt`).
+
+### Configuration file
+
+The `keybindings.json` file contains a mapping of actions to key names. An example configuration looks like:
+
+```json
+{
+  "up": "Up",
+  "down": "Down",
+  "edit": "e",
+  "new_note": "Enter",
+  "new_section": "s",
+  "save": "w",
+  "load": "l",
+  "file_menu": "f",
+  "quit": "q",
+  "cancel": "Esc",
+  "bindings": "b",
+  "theme": "t",
+  "time_hack": "h"
+}
+```
 
 ## Library Usage
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -217,7 +217,13 @@ impl KeyBindings {
     #[must_use]
     pub fn load_or_default() -> Self {
         let path = Self::config_path();
-        if let Ok(data) = fs::read_to_string(&path) {
+        Self::load_or_default_from(&path)
+    }
+
+    /// Loads key bindings from the provided file or returns defaults.
+    #[must_use]
+    pub fn load_or_default_from(path: &Path) -> Self {
+        if let Ok(data) = fs::read_to_string(path) {
             if let Ok(cfg) = serde_json::from_str::<KeyBindingsConfig>(&data) {
                 return cfg.into();
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ mod key_utils;
 mod theme;
 mod ui;
 
-pub use app::{Action, App, AppError, Entry, InputMode, Note, Section};
+pub use app::{Action, App, AppError, Entry, InputMode, KeyBindings, Note, Section};
 pub use key_utils::{key_to_string, string_to_key};
 use std::io;
 pub use theme::{Theme, ThemeName};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,30 +1,64 @@
 #![warn(clippy::pedantic)]
-use clap::{ArgAction, Parser};
-use real_time_note_taker::{run, App};
+use clap::{ArgAction, CommandFactory, Parser, Subcommand};
+use clap_complete::{generate, Shell};
+use log::LevelFilter;
+use real_time_note_taker::{run, App, KeyBindings};
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Generate shell completion script for the specified shell
+    Completions { shell: Shell },
+}
 
 #[derive(Parser)]
 #[command(author, version, about)]
 struct Cli {
-    /// Show version information
-    #[arg(short = 'v', long = "version-info", alias = "v", action = ArgAction::SetTrue)]
-    version_info: bool,
-
     /// Load notes from this file and save them on exit
     #[arg(long)]
     file: Option<std::path::PathBuf>,
+
+    /// Override the default directory for saved files
+    #[arg(long)]
+    save_dir: Option<std::path::PathBuf>,
+
+    /// Path to an alternative key binding configuration file
+    #[arg(long)]
+    config: Option<std::path::PathBuf>,
+
+    /// Increase logging verbosity (-v, -vv, etc.)
+    #[arg(short, long, action = ArgAction::Count)]
+    verbose: u8,
+
+    #[command(subcommand)]
+    command: Option<Commands>,
 }
 
 fn main() -> std::io::Result<()> {
     let cli = Cli::parse();
-    if cli.version_info {
-        print_version_info();
+    init_logger(cli.verbose);
+
+    if let Some(Commands::Completions { shell }) = cli.command {
+        let mut cmd = Cli::command();
+        generate(shell, &mut cmd, "rtnt", &mut std::io::stdout());
         return Ok(());
     }
+
     let mut app = if let Some(ref file) = cli.file {
         App::load_from_file(file).unwrap_or_else(|_| App::new())
     } else {
         App::new()
     };
+
+    if let Some(save_dir) = cli.save_dir {
+        std::fs::create_dir_all(&save_dir)?;
+        app.save_dir = save_dir;
+    }
+
+    if let Some(cfg) = cli.config {
+        let keys = KeyBindings::load_or_default_from(&cfg);
+        app.set_keybindings(keys);
+    }
+
     app = run(app)?;
     if let Some(file) = cli.file {
         app.save_to_file(file)?;
@@ -32,8 +66,16 @@ fn main() -> std::io::Result<()> {
     Ok(())
 }
 
-fn print_version_info() {
-    println!("rtnt {}", env!("CARGO_PKG_VERSION"));
+fn init_logger(verbosity: u8) {
+    let level = match verbosity {
+        0 => LevelFilter::Warn,
+        1 => LevelFilter::Info,
+        2 => LevelFilter::Debug,
+        _ => LevelFilter::Trace,
+    };
+    let _ = env_logger::Builder::from_default_env()
+        .filter_level(level)
+        .try_init();
 }
 
 #[cfg(test)]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -10,17 +10,11 @@ fn runs_help() {
 #[test]
 fn runs_version() {
     let mut cmd = Command::cargo_bin("rtnt").unwrap();
-    cmd.arg("--version").assert().success();
+    cmd.arg("-V").assert().success();
 }
 
 #[test]
-fn runs_lowercase_v() {
+fn runs_verbose() {
     let mut cmd = Command::cargo_bin("rtnt").unwrap();
-    cmd.arg("-v").assert().success();
-}
-
-#[test]
-fn runs_double_dash_v() {
-    let mut cmd = Command::cargo_bin("rtnt").unwrap();
-    cmd.arg("--v").assert().success();
+    cmd.args(["-v", "--help"]).assert().success();
 }


### PR DESCRIPTION
## Summary
- add dependencies for logging and shell completions
- implement new CLI flags (`--save-dir`, `--config`, `-v/--verbose`)
- add `completions` subcommand
- support loading keybindings from custom path
- export `KeyBindings` from library
- update README with CLI usage and configuration file example
- adjust tests for new CLI behavior

